### PR TITLE
feat(print): add printing action item to account lists

### DIFF
--- a/app/views/accounts/_account.html.haml
+++ b/app/views/accounts/_account.html.haml
@@ -8,3 +8,4 @@
   %td.action-links
     = list_link_for(:edit, account)
     = list_link_for(:delete, account)
+    = list_link_to :print, account_path(account, :format => :pdf, :per_page => 5000)


### PR DESCRIPTION
To allow quickly printing all account statements we add an action item
link to the entries in the account list.
