### PR TITLE
account booking filter

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,7 +1,9 @@
 class AccountsController < HasAccountsController
   # Scopes
-  has_scope :by_date, :using => [:from, :to], :default => proc { |c| c.session[:has_scope] }
+  has_scope :by_code
   has_scope :by_text
+  has_scope :by_amount, :using => [:from, :to]
+  has_scope :by_date, :using => [:from, :to]
 
   has_scope :page, :only => :index
 
@@ -28,8 +30,6 @@ class AccountsController < HasAccountsController
     if @account.profit_account? && params[:by_date] && params[:by_date][:to]
       @saldo -= @account.saldo(Date.parse(params[:by_date][:from]), false)
     end
-
-    show!
   end
 
   def csv_bookings

--- a/app/views/accounts/_bookings_list.html.haml
+++ b/app/views/accounts/_bookings_list.html.haml
@@ -1,0 +1,11 @@
+= paginate @bookings, :remote => true
+
+%table.table.table-striped.bookings.collection
+  %thead
+    = render 'accounts/booking_list_header'
+  %tbody
+    - @saldo = ''
+    - for @booking in @bookings
+      = render 'accounts/booking_item'
+
+= paginate @bookings

--- a/app/views/accounts/_show_bookings.html.haml
+++ b/app/views/accounts/_show_bookings.html.haml
@@ -1,17 +1,20 @@
-= paginate @bookings
+= render 'bookings/filter_form'
 
-%table.table.table-striped.bookings.collection
-  %thead
-    = render 'accounts/booking_list_header'
-  %tbody
-    = render 'accounts/carry_booking' unless @saldo == 0
+.index
+  = paginate @bookings
 
-    - for @booking in @bookings
-      - amount = @booking.amount
-      - amount = -(amount) if @account.liability_account?
-      - @saldo += @booking.accounted_amount(@account)
-      = render 'accounts/booking_item'
-  %tfoot
-    = render 'accounts/booking_list_footer' unless @bookings.empty?
+  %table.table.table-striped.bookings.collection
+    %thead
+      = render 'accounts/booking_list_header'
+    %tbody
+      = render 'accounts/carry_booking' unless @saldo == 0
 
-= paginate @bookings
+      - for @booking in @bookings
+        - amount = @booking.amount
+        - amount = -(amount) if @account.liability_account?
+        - @saldo += @booking.accounted_amount(@account)
+        = render 'accounts/booking_item'
+    %tfoot
+      = render 'accounts/booking_list_footer' unless @bookings.empty?
+
+  = paginate @bookings

--- a/app/views/accounts/_show_bookings.html.haml
+++ b/app/views/accounts/_show_bookings.html.haml
@@ -1,5 +1,3 @@
-- url_params = {:controller => 'accounts', :action => 'show', :id => params[:account_id] || params[:id]}
-
 = paginate @bookings
 
 %table.table.table-striped.bookings.collection

--- a/app/views/accounts/show.js.erb
+++ b/app/views/accounts/show.js.erb
@@ -1,0 +1,3 @@
+$('#tab-bookings .index').html('<%=escape_javascript render "bookings_list" %>');
+initializeBehaviours();
+


### PR DESCRIPTION
It re-uses the filter used in the booking journal. 

This is an alternative PR for #10:
- hides the saldo column
- uses AJAX -> faster :-)
- is consistent with booking journal form

Some issues:
- pagination falls back to non-AJAX and will badly spot saldo and carry info
- printing does not take filter into account
- need patching of sub-class controllers of Accounts like in Bookyt:

```
diff --git i/app/controllers/bank_accounts_controller.rb w/app/controllers/bank_accounts_controller.rb
index ed594c7..1f8e6c5 100644
--- i/app/controllers/bank_accounts_controller.rb
+++ w/app/controllers/bank_accounts_controller.rb
@@ -1,3 +1,4 @@
 class BankAccountsController < AccountsController
   defaults resource_class: BankAccount
+  skip_load_and_authorize_resource :only => :show
 end
```
